### PR TITLE
Make FindCollidablePartOnRay an openable thing, so other scripts can modify it nicer

### DIFF
--- a/src/Character/Controller/Visual/Arc.lua
+++ b/src/Character/Controller/Visual/Arc.lua
@@ -16,7 +16,7 @@ local Workspace = game:GetService("Workspace")
 local Players = game:GetService("Players")
 
 local NexusVRCharacterModel = script.Parent.Parent.Parent.Parent
-local FindCollidablePartOnRay = require(NexusVRCharacterModel:WaitForChild("Util"):WaitForChild("FindCollidablePartOnRay"))
+local FindCollidablePartOnRay = require(NexusVRCharacterModel:WaitForChild("Util"):WaitForChild("FindCollidablePartOnRay")).FindCollidablePartOnRay
 
 local Arc = {}
 Arc.__index = Arc

--- a/src/Character/FootPlanter.lua
+++ b/src/Character/FootPlanter.lua
@@ -103,7 +103,7 @@ function FootPlanter:CreateSolver(CenterPart,ScaleValue)
 		return atan2(lookVector.X,lookVector.Z)
 	end
 	
-	local FindCollidablePartOnRay = require(script.Parent.Parent:WaitForChild("Util"):WaitForChild("FindCollidablePartOnRay"))
+	local FindCollidablePartOnRay = require(script.Parent.Parent:WaitForChild("Util"):WaitForChild("FindCollidablePartOnRay")).FindCollidablePartOnRay
 	local function FindPartOnRay(ray,ignore)
 		return FindCollidablePartOnRay(ray.Origin,ray.Direction,ignore,CenterPart)
 	end

--- a/src/Util/FindCollidablePartOnRay.lua
+++ b/src/Util/FindCollidablePartOnRay.lua
@@ -58,4 +58,4 @@ end
 
 
 
-return FindCollidablePartOnRay
+return { FindCollidablePartOnRay = FindCollidablePartOnRay }


### PR DESCRIPTION
I wanted to change ``FindCollidablePartOnRay`` to filter out rays. Since it is like it's standalone Utility function. I changed it so that another script can require it and then override the behavior to their own liking.

Like that one can do that but still keep an updated version of the Module, without having to re-upload it entirely.

Now one can just require it and replace ``.FindCollidablePartOnRay =`` to override the function.